### PR TITLE
add layer freezing and skip_mismatch support for fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ usage: train.py [-h] [--operation {train,fine-tune}] --data_dir DATA_DIR
                 [--validation_set_percentage VALIDATION_SET_PERCENTAGE]
                 [--filter_by_classes FILTER_BY_CLASSES]
                 [--backbone {ResNet50,ResNet101,ResNet152,VGG16}]
+                [--frozen_layer_groups FROZEN_LAYER_GROUPS]
+                [--skip_mismatch SKIP_MISMATCH]
 
 Run training or fine-tuning
 
@@ -179,6 +181,19 @@ optional arguments:
                         "1,2,6" to filter by classes 1, 2 and 6)
   --backbone {ResNet50,ResNet101,ResNet152,VGG16}
                         Backbone architecture
+  --frozen_layer_groups FROZEN_LAYER_GROUPS
+                        ONLY FOR OPERATION == FINE-TUNE: Comma-separated list
+                        of layer-name patterns to freeze after loading donor
+                        weights. Substring matching is used, so
+                        "downsampling_block0" freezes all layers whose name
+                        contains that string. Pass "all" to freeze the entire
+                        backbone and train only the classifier head.
+                        E.g. "downsampling_block0,downsampling_block1"
+  --skip_mismatch SKIP_MISMATCH
+                        ONLY FOR OPERATION == FINE-TUNE: Skip layers whose
+                        weight shapes differ from the donor checkpoint
+                        (default True). Useful when the number of bands or
+                        classes changed between the donor and target datasets.
 ```
 
 ## Detection

--- a/bin/train.py
+++ b/bin/train.py
@@ -123,6 +123,21 @@ if __name__ == '__main__':
         '--backbone', type=str, default=None,
         choices=('ResNet50', 'ResNet101', 'ResNet152', 'VGG16'),
         help='Backbone architecture')
+    parser.add_argument(
+        '--frozen_layer_groups', type=str, default=None,
+        help='ONLY FOR OPERATION == FINE-TUNE: Comma-separated list of '
+             'layer-name patterns to freeze after loading donor weights. '
+             'Substring matching is used, so "downsampling_block0" freezes '
+             'all layers whose name contains that string. '
+             'Pass "all" to freeze the entire backbone and train only the '
+             'classifier head. '
+             'E.g. "downsampling_block0,downsampling_block1"')
+    parser.add_argument(
+        '--skip_mismatch', type=bool_, default=True,
+        help='ONLY FOR OPERATION == FINE-TUNE: Skip layers whose weight '
+             'shapes differ from the donor checkpoint (default True). '
+             'Useful when the number of bands or classes changed between '
+             'the donor and target datasets.')
 
     args = parser.parse_args()
 
@@ -145,6 +160,11 @@ if __name__ == '__main__':
             'Argument validation_set_percentage must be greater or equal to '
             '0 and smaller or equal than 1')
 
+    frozen_layer_groups = None
+    if args.frozen_layer_groups:
+        frozen_layer_groups = [g.strip()
+                               for g in args.frozen_layer_groups.split(',')]
+
     from cnn_lib.train import run
 
     run(args.operation, args.data_dir, args.output_dir, args.model,
@@ -156,4 +176,5 @@ if __name__ == '__main__':
         args.augment_training_dataset, args.tversky_alpha,
         args.tversky_beta, args.dropout_rate_input,
         args.dropout_rate_hidden, args.validation_set_percentage,
-        args.filter_by_classes, args.backbone)
+        args.filter_by_classes, args.backbone,
+        frozen_layer_groups=frozen_layer_groups, skip_mismatch=args.skip_mismatch)

--- a/cnn_lib/architectures.py
+++ b/cnn_lib/architectures.py
@@ -160,6 +160,21 @@ class _BaseModel(Model, ABC):
         """
         return super(_BaseModel, self).get_config()
 
+    def set_layers_trainable(self, trainable, patterns=None):
+        """Set layers trainable or frozen by name pattern, or all layers if none given.
+
+        Call model.compile() afterwards to re-register trainable variables
+        with Keras.
+
+        :param trainable: True to unfreeze, False to freeze.
+        :param patterns: list of substrings to match against layer names
+            (case-insensitive). E.g. ['downsampling_block0', 'middle_block'].
+            If None or empty, all layers are affected.
+        """
+        for layer in self.layers:
+            if patterns is None or any(p.lower() in layer.name.lower()
+                                       for p in patterns):
+                layer.trainable = trainable
 
 class UNet(_BaseModel):
     """U-Net architecture.

--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -23,7 +23,7 @@ def run(operation, data_dir, output_dir, model, model_fn, input_regex='*.tif',
         force_dataset_generation=False, fit_memory=False, augment=False,
         tversky_alpha=0.5, tversky_beta=0.5, dropout_rate_input=None,
         dropout_rate_hidden=None, val_set_pct=0.2, filter_by_class=None,
-        backbone=None, name=None, verbose=1, frozen_layer_groups=None, skip_mismatch=True):
+        backbone=None, name=None, frozen_layer_groups=None, skip_mismatch=True, verbose=1):
     if verbose > 0:
         utils.print_device_info()
 

--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -66,7 +66,7 @@ def run(operation, data_dir, output_dir, model, model_fn, input_regex='*.tif',
                 model.layers[-1].trainable = True
             else:
                 model.set_layers_trainable(False, frozen_layer_groups)
-                model.compile(
+            model.compile(
                     optimizer=model.optimizer,
                     loss=model.loss,
                     metrics=model.compiled_metrics._metrics)

--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -23,7 +23,7 @@ def run(operation, data_dir, output_dir, model, model_fn, input_regex='*.tif',
         force_dataset_generation=False, fit_memory=False, augment=False,
         tversky_alpha=0.5, tversky_beta=0.5, dropout_rate_input=None,
         dropout_rate_hidden=None, val_set_pct=0.2, filter_by_class=None,
-        backbone=None, name=None, verbose=1):
+        backbone=None, name=None, verbose=1, frozen_layer_groups=None, skip_mismatch=True):
     if verbose > 0:
         utils.print_device_info()
 
@@ -59,7 +59,17 @@ def run(operation, data_dir, output_dir, model, model_fn, input_regex='*.tif',
 
     # load weights if the model is supposed to do so
     if operation == 'fine-tune':
-        model.load_weights(in_weights_path)
+        model.load_weights(in_weights_path, skip_mismatch=skip_mismatch)
+        if frozen_layer_groups:
+            if frozen_layer_groups == ['all']:
+                model.set_layers_trainable(False)
+                model.layers[-1].trainable = True
+            else:
+                model.set_layers_trainable(False, frozen_layer_groups)
+                model.compile(
+                    optimizer=model.optimizer,
+                    loss=model.loss,
+                    metrics=model.compiled_metrics._metrics)
 
     train_generator = AugmentGenerator(
         data_dir, input_regex, batch_size, 'train', fit_memory=fit_memory,


### PR DESCRIPTION
As fine-tuning between datasets requires layer freezing and tolerance for weight shape mismatches when band or class counts differ, following changes were made:

- `_BaseModel.set_layers_trainable(trainable, patterns)` — freeze/unfreeze
  layers by name pattern
- `model.load_weights()` now passes `skip_mismatch`
- `--frozen_layer_groups` CLI argument — comma-separated layer name patterns
  to freeze after loading weights. Pass `"all"` for full backbone freeze
- `--skip_mismatch` CLI argument — skip mismatched layers when loading (default True)

Fix #2