### PR TITLE
Fix data leakage between train and val sets

### DIFF
--- a/cnn_lib/data_preparation.py
+++ b/cnn_lib/data_preparation.py
@@ -207,8 +207,9 @@ def tile(
             else:
                 mask_array = None
 
+            dir_name = next(dir_names)
+
             for rot_k in rotations:
-                dir_name = next(dir_names)
                 suffix = f'_rot{rot_k * 90}' if rot_k > 0 else ''
 
                 out_scene_path = os.path.join(

--- a/cnn_lib/data_preparation.py
+++ b/cnn_lib/data_preparation.py
@@ -208,8 +208,9 @@ def tile(
                 mask_array = None
 
             dir_name = next(dir_names)
+            active_rotations = rotations if dir_name == 'train' else (0,)
 
-            for rot_k in rotations:
+            for rot_k in active_rotations:
                 suffix = f'_rot{rot_k * 90}' if rot_k > 0 else ''
 
                 out_scene_path = os.path.join(

--- a/cnn_lib/detect.py
+++ b/cnn_lib/detect.py
@@ -67,6 +67,7 @@ def run(
         if int(tf.__version__.split('.')[1]) < 4:
             tf.random.set_seed(seed)
         else:
+            tf.random.set_seed(seed)
             tf.keras.utils.set_random_seed(seed)
 
     model = create_model(

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 1321.33557, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
+Epoch 1: val_loss improved from inf to 494.25861, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
 
-Epoch 2: val_loss improved from 1321.33557 to 3.71835, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
+Epoch 2: val_loss improved from 494.25861 to 1.09180, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 494.25861, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
+Epoch 1: val_loss improved from inf to 1321.33557, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
 
-Epoch 2: val_loss improved from 494.25861 to 1.09180, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5
+Epoch 2: val_loss improved from 1321.33557 to 3.71835, saving model to /tmp/output_u-net_drop0_categorical_crossentropy/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy_augment"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 2.48105, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 1: val_loss improved from inf to 1.80235, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
 
-Epoch 2: val_loss improved from 2.48105 to 2.28520, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 2: val_loss improved from 1.80235 to 1.06687, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy_augment"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 14.77218, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 1: val_loss improved from inf to 2.48105, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
 
-Epoch 2: val_loss improved from 14.77218 to 2.53535, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 2: val_loss improved from 2.48105 to 2.28520, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy_augment"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 6.95600, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 1: val_loss improved from inf to 14.77218, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
 
-Epoch 2: val_loss improved from 6.95600 to 0.99012, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 2: val_loss improved from 14.77218 to 2.53535, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_categorical_crossentropy_augment.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_categorical_crossentropy_augment"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 1.80235, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 1: val_loss improved from inf to 2.48105, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
 
-Epoch 2: val_loss improved from 1.80235 to 1.06687, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5
+Epoch 2: val_loss improved from 2.48105 to 2.28520, saving model to /tmp/output_u-net_drop0_categorical_crossentropy_augment/model.weights.h5

--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -72,6 +72,7 @@ def run(
         if int(tf.__version__.split('.')[1]) < 4:
             tf.random.set_seed(seed)
         else:
+            tf.random.set_seed(seed)
             tf.keras.utils.set_random_seed(seed)
 
     model = create_model(


### PR DESCRIPTION
During dataset generation, `next(dir_names)` was called inside the rotation loop, meaning different rotations of the same tile could be assigned to different sets (train/val). I think this causes data leakage between train and val sets leading to lower val_loss than it should be.

## Changes

- Moved `dir_name = next(dir_names)` outside the rotation loop so all augmented versions of the same tile are always assigned to the same set.

## Note

I also changed the behavior so val tiles are not augmented — only the original orientation is used for validation. The reason is that validation should simulate real inference conditions. I think it is fine with rotations only, but if more augmentation strategies were added in the future, it could become a bigger issue. Note that this will likely fail the consistency tests, as new reference results probably need to be generated with this fix applied.