### PR TITLE
Fix: avoid NaN loss when batch contains only ignore-value pixels

### DIFF
--- a/cnn_lib/lib.py
+++ b/cnn_lib/lib.py
@@ -368,10 +368,15 @@ def categorical_tversky(
     numerator = tf.reduce_sum(true_pos, axis=(1, 2))
     denominator = true_pos + alpha * false_neg + beta * false_pos
     denominator = tf.reduce_sum(denominator, axis=(1, 2))
-    tversky = numerator / denominator
+    tversky = numerator / (denominator + 1e-7)
 
-    # reduce mean for batches
-    tversky = tf.reduce_mean(tversky, axis=0)
+    # average only over valid tiles
+    batch_valid = tf.cast(
+        tf.reduce_sum(pixel_has_class, axis=(1, 2)) > 0, tf.float32
+    )
+    tversky = tf.reduce_sum(tversky * tf.expand_dims(batch_valid, -1), axis=0) / (
+            tf.reduce_sum(batch_valid) + 1e-7
+    )
 
     # reduce mean for classes and multiply them by weights
     loss = 1 - tf.reduce_mean(weight_tensor * tversky)
@@ -409,7 +414,7 @@ def masked_crossentropy(ground_truth_onehot, predictions, binary=False):
 
     per_pixel_loss = loss_fn(ground_truth_onehot, predictions)
     masked_loss = per_pixel_loss * valid_mask
-    loss = tf.reduce_sum(masked_loss) / tf.reduce_sum(valid_mask)
+    loss = tf.reduce_sum(masked_loss) / (tf.reduce_sum(valid_mask)+1e-7)
 
     return loss
 

--- a/cnn_lib/lib.py
+++ b/cnn_lib/lib.py
@@ -374,9 +374,9 @@ def categorical_tversky(
     batch_valid = tf.cast(
         tf.reduce_sum(pixel_has_class, axis=(1, 2)) > 0, tf.float32
     )
-    tversky = tf.reduce_sum(tversky * tf.expand_dims(batch_valid, -1), axis=0) / (
-            tf.reduce_sum(batch_valid) + 1e-7
-    )
+    tversky = tf.reduce_sum(
+        tversky * tf.expand_dims(batch_valid, -1), axis=0
+    ) / (tf.reduce_sum(batch_valid) + 1e-7)
 
     # reduce mean for classes and multiply them by weights
     loss = 1 - tf.reduce_mean(weight_tensor * tversky)
@@ -414,7 +414,7 @@ def masked_crossentropy(ground_truth_onehot, predictions, binary=False):
 
     per_pixel_loss = loss_fn(ground_truth_onehot, predictions)
     masked_loss = per_pixel_loss * valid_mask
-    loss = tf.reduce_sum(masked_loss) / (tf.reduce_sum(valid_mask)+1e-7)
+    loss = tf.reduce_sum(masked_loss) / (tf.reduce_sum(valid_mask) + 1e-7)
 
     return loss
 

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_dice.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_dice.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_dice"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 0.94762, saving model to /tmp/output_u-net_drop0_dice/model.weights.h5
+Epoch 1: val_loss improved from inf to 0.91683, saving model to /tmp/output_u-net_drop0_dice/model.weights.h5
 
-Epoch 2: val_loss improved from 0.94762 to 0.52323, saving model to /tmp/output_u-net_drop0_dice/model.weights.h5
+Epoch 2: val_loss improved from 0.91683 to 0.65998, saving model to /tmp/output_u-net_drop0_dice/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_tversky_0.3_0.7.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_tversky_0.3_0.7.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_tversky_0.3_0.7"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 0.83649, saving model to /tmp/output_u-net_drop0_tversky_0.3_0.7/model.weights.h5
+Epoch 1: val_loss improved from inf to 0.74592, saving model to /tmp/output_u-net_drop0_tversky_0.3_0.7/model.weights.h5
 
-Epoch 2: val_loss improved from 0.83649 to 0.73259, saving model to /tmp/output_u-net_drop0_tversky_0.3_0.7/model.weights.h5
+Epoch 2: val_loss improved from 0.74592 to 0.65679, saving model to /tmp/output_u-net_drop0_tversky_0.3_0.7/model.weights.h5

--- a/cnn_lib/test/consistency_outputs/u-net_drop0_tversky_0.7_0.3.txt
+++ b/cnn_lib/test/consistency_outputs/u-net_drop0_tversky_0.7_0.3.txt
@@ -87,6 +87,6 @@ Model: "u-net_drop0_tversky_0.7_0.3"
  Trainable params: 31,048,835 (118.44 MB)
  Non-trainable params: 11,776 (46.00 KB)
 
-Epoch 1: val_loss improved from inf to 0.65414, saving model to /tmp/output_u-net_drop0_tversky_0.7_0.3/model.weights.h5
+Epoch 1: val_loss improved from inf to 0.74864, saving model to /tmp/output_u-net_drop0_tversky_0.7_0.3/model.weights.h5
 
-Epoch 2: val_loss improved from 0.65414 to 0.44669, saving model to /tmp/output_u-net_drop0_tversky_0.7_0.3/model.weights.h5
+Epoch 2: val_loss improved from 0.74864 to 0.49113, saving model to /tmp/output_u-net_drop0_tversky_0.7_0.3/model.weights.h5


### PR DESCRIPTION
`categorical_tversky` produced `NaN` loss when a tile contained only
ignore-value pixels (e.g. 255). `valid_mask` correctly zeroed out pixel
contributions, but this still caused division by zero during tversky
computation:

```python
numerator = 0
denominator = 0
tversky = 0 / 0 = NaN
```

A single NaN tile then propagated NaN to the entire batch loss via
`tf.reduce_mean`.

The same issue is probably present (not tested) in `masked_crossentropy` where
`tf.reduce_sum(valid_mask) = 0` can cause the same division by zero.

## Changes

**`categorical_tversky`** — add epsilon to denominator and average only
over tiles with at least one valid pixel:

```python
tversky = numerator / (denominator + 1e-7)

batch_valid = tf.cast(
    tf.reduce_sum(pixel_has_class, axis=(1, 2)) > 0, tf.float32
)
tversky = tf.reduce_sum(tversky * tf.expand_dims(batch_valid, -1), axis=0) / (
    tf.reduce_sum(batch_valid) + 1e-7
)
```

**`masked_crossentropy`** — add epsilon to denominator:

```python
loss = tf.reduce_sum(masked_loss) / (tf.reduce_sum(valid_mask) + 1e-7)
```