### PR TITLE
Fix Keras compiled metrics API for fine-tune recompilation

### DIFF
--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -107,6 +107,7 @@ def run(
 
     # load weights if the model is supposed to do so
     if operation == 'fine-tune':
+        _metrics = [m for m in model.metrics if m.name != 'loss']
         model.load_weights(in_weights_path, skip_mismatch=skip_mismatch)
         if frozen_layer_groups:
             if frozen_layer_groups == ['all']:
@@ -117,8 +118,7 @@ def run(
             model.compile(
                 optimizer=model.optimizer,
                 loss=model.loss,
-                metrics=model.metrics_names[1:]
-            )
+                metrics=_metrics)
 
     train_generator = AugmentGenerator(
         data_dir,

--- a/cnn_lib/train.py
+++ b/cnn_lib/train.py
@@ -117,7 +117,7 @@ def run(
             model.compile(
                 optimizer=model.optimizer,
                 loss=model.loss,
-                metrics=model.compiled_metrics._metrics,
+                metrics=model.metrics_names[1:]
             )
 
     train_generator = AugmentGenerator(


### PR DESCRIPTION
### Problem

When running `--operation fine-tune` with `--frozen_layer_groups`, the training crashed with:

```
AttributeError: 'DeprecatedCompiledMetric' object has no attribute '_metrics'
```

### Fix

Metric objects are now captured before `load_weights()` is called, using the `model.metrics`:

```python
_metrics = [m for m in model.metrics if m.name != 'loss']
model.load_weights(in_weights_path, skip_mismatch=skip_mismatch)
...
model.compile(
    optimizer=model.optimizer,
    loss=model.loss,
    metrics=_metrics)
```